### PR TITLE
Follow FactoryPrototype for StoreViewPrototype

### DIFF
--- a/book/02-goals.md
+++ b/book/02-goals.md
@@ -3,8 +3,8 @@
 - [ ] Window behavior on data changes
   - [ ] Window transitions
     - [x] Add new record
-    - [ ] Slide
-    - [ ] Remove
+    - [ ] Slide/reorder
+    - [x] Remove
   - [ ] View follows transitions
 - [ ] Relative scrolling
 - [ ] Sorting
@@ -32,29 +32,6 @@
   - [x] Replaces relm4 factory
   - [ ] Event propagation to the listeners of the view
 
-## User friendliness
-
-These goals are making usage of the library easier
-
-- [ ] Book
-  - [x] Todo 1
-  - [ ] Todo 2
-  - [ ] Todo 3
-  - [ ] Todo 4
-- [ ] Examples
-  - [x] Todo 1 - really simple todo
-  - [x] Todo 2 - todo 1 with pagination
-  - [x] Todo 4 - todo 2 with sorting
-  - [x] Window behavior - todo 4 many times over
-  
-- [x] rustdoc
-
 ## Missing things
 
-- [ ] Remove records, for now you can reload the view after remove
-- [ ] Reorder records, for now you can reload the view after move
-- [x] Add records
-  - [x] At the beginning
-  - [x] At the end
-  - [x] Somewhere between the elements
-- [x] Remove dependency to StoreMsg if things are not related to store
+- [ ] Reorder records, for now it triggers reload on the store

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -27,3 +27,6 @@
   - [Simple todo 4](./examples/04-todo/README.md)
     - [View](./examples/04-todo/01-view.md)
     - [configuration](./examples/04-todo/02-configuration.md)
+- [Releases](./releases/README.md)
+  - [0.1-beta.2](./releases/0.1-beta.2.md)
+  - [0.1-beta.1](./releases/0.1-beta.1.md)

--- a/book/examples/01-setup.md
+++ b/book/examples/01-setup.md
@@ -6,12 +6,12 @@ All examples in this book are using this dependencies in `Cargo.toml`
 
 ```toml
 [dependencies]
-reexport = { package = "relm4-store-reexport", version="0.1.0-beta.1" }
-record = { package = "relm4-store-record", version = "0.1.0-beta.1" }
-store = { package = "relm4-store", version = "0.1.0-beta.1" }
-store-view = { package = "relm4-store-view-implementation", version = "0.1.0-beta.1"}
-backend_inmemory = { package = "relm4-store-backend-inmemory", version = "0.1.0-beta.1" }
-components = { package = "relm4-store-components", version = "0.1.0-beta.1" }
+reexport = { package = "relm4-store-reexport", version="0.1.0-beta.2" }
+record = { package = "relm4-store-record", version = "0.1.0-beta.2" }
+store = { package = "relm4-store", version = "0.1.0-beta.2" }
+store-view = { package = "relm4-store-view-implementation", version = "0.1.0-beta.2"}
+backend_inmemory = { package = "relm4-store-backend-inmemory", version = "0.1.0-beta.2" }
+components = { package = "relm4-store-components", version = "0.1.0-beta.2" }
 log4rs = "1.0.0"
 ```
 

--- a/book/examples/01-todo/03-task_list.md
+++ b/book/examples/01-todo/03-task_list.md
@@ -91,9 +91,9 @@ This method is responsible for creating instance of the store view. In here you 
 
 #### `relm4::factory::FactoryPrototype`
 
-Next we implemented `generate`, `update_record`, `position` and `get_root` methods. Three methods `generate`, `position`, `get_root` are the same as in `FactoryPrototype`. `update_record` is the `update` method from `FactoryPrototype`.
+Next we implemented `init_view`, `view`, `position` and `root_widget` methods. All four methods are equivalents of the methods with the same name in `FactoryPrototype`.
 
-#### `update` and `init_view_model`
+#### `relm4::ComponentUpdate`
 
 This method is equivalent of `update` for `ComponentUpdate`.  `init_view_model` is `init_model` from `ComponentUpdate`.
 
@@ -117,7 +117,7 @@ Second is
 {{#include ../../../relm4-store-examples/examples/todo_1/view/task_list.rs:212:215}}
 ```
 
-In here we've named container handling our list of tasks. It's important so the component knows which element to provide to relm4's `Factory` generate method.
+In here we've named container handling our list of tasks. It's important so the component knows which element to provide to relm4's `Factory::init_view` method.
 
 Rest is classic relm4.
 

--- a/book/examples/04-todo/01-view.md
+++ b/book/examples/04-todo/01-view.md
@@ -21,7 +21,7 @@ We need to add `Delete` event to the `TaskMsg` so we can track which record shou
 {{#include ../../../relm4-store-examples/examples/todo_4/view/task_list.rs:45:52}}
 ```
 
-Now we need to update the `generate` method in the implementation of the `StoreViewPrototype` for `TaskListViewModel`
+Now we need to update the `init_view` method in the implementation of the `StoreViewPrototype` for `TaskListViewModel`
 
 ```rust,noplaypen
 {{#include ../../../relm4-store-examples/examples/todo_4/view/task_list.rs:85:86}}
@@ -45,7 +45,7 @@ it will send `TaskMsg::Delete`. To make ui nice we in the `label` we've added to
 
 This will expand horizontally and text will be left aligned.
 
-Last thing left to do is to handle the changes in the `update` method in the implementation of `StoreViewPrototype` for `TaskListViewModel`.
+Last thing left to do is to handle the changes in the `view` method in the implementation of `StoreViewPrototype` for `TaskListViewModel`.
 Compiler will tell you exactly where.
 
 ```rust,noplaypen

--- a/book/releases/0.1-beta.1.md
+++ b/book/releases/0.1-beta.1.md
@@ -1,0 +1,3 @@
+# Release 0.1-beta.1
+
+It's first release ever. Early beta one.

--- a/book/releases/0.1-beta.2.md
+++ b/book/releases/0.1-beta.2.md
@@ -1,0 +1,36 @@
+# Release 0.1-beta.2
+
+## Release status
+
+Early beta
+
+## Changes
+
+- `relm4` dependency got updated to `relm4-0.4.1` [issue #21](https://github.com/mskorkowski/relm4-store/issues/21)
+- Removing records from store [issue #14](https://github.com/mskorkowski/relm4-store/issues/14)
+- `DataContainer` got moved into `relm4-store-collections` crate [issue #13](https://github.com/mskorkowski/relm4-store/issues/13)
+- `DataContainer::invariants` are only run on the `dev/debug` releases [issue #27](https://github.com/mskorkowski/relm4-store/issues/27)
+- more unit tests
+
+This release was tracked under [issue 0.1-beta.2](https://github.com/mskorkowski/relm4-store/issues/15)
+
+## Migration from 0.1-beta.1 to 0.1-beta.2
+
+### StoreViewPrototype
+
+`relm4_store::StoreViewPrototype` methods got updated to follow `relm4::factory::FactoryPrototype`
+
+- `generate` => `init_view`
+- `update_record` => `view`
+- `get_root` => `root_widget`
+
+Full status of methods in `StoreViewPrototype`
+
+| 0.1-beta.1 method name | 0.1-beta.2 method name | reason                                 |
+|:-----------------------|:-----------------------|:---------------------------------------|
+| generate               | init_view              | follow `FactoryPrototype` update       |
+| update_record          | view                   | follow `FacroryPrototype` update       |
+| get_root               | root_widget            | follow `FactoryPrototype` update       |
+| position               | position               | not changed in `FactoryPrototype`      |
+| init_view_model        | init_view_model        | not changed, follows `ComponentUpdate` |
+| update                 | update                 | not changed, follows `ComponentUpdate` |

--- a/book/releases/README.md
+++ b/book/releases/README.md
@@ -1,0 +1,7 @@
+# Releases
+
+## Current release
+
+Current release version is `0.1-beta.2`
+
+On the release page you can find a migration guide from `0.1-beta.1`

--- a/relm4-store-examples/examples/todo_1/view/task_list.rs
+++ b/relm4-store-examples/examples/todo_1/view/task_list.rs
@@ -135,7 +135,7 @@ impl<Config: TasksListConfiguration> StoreViewPrototype
     }
 
     /// Function called when record is modified.
-    fn view_record(
+    fn view(
         record: Task,
         _position: Position,
         widgets: &Self::RecordWidgets,
@@ -157,7 +157,7 @@ impl<Config: TasksListConfiguration> StoreViewPrototype
         &widgets.root
     }
 
-    fn view(
+    fn update(
         view_model: &mut Self::ViewModel, 
         msg: <Self as ViewModel>::Msg, 
         _sender: Sender<<Self as ViewModel>::Msg>

--- a/relm4-store-examples/examples/todo_2/view/task_list.rs
+++ b/relm4-store-examples/examples/todo_2/view/task_list.rs
@@ -142,7 +142,7 @@ where Config: TasksListConfiguration + 'static,
     }
 
     /// Function called when record is modified.
-    fn view_record(
+    fn view(
         record: Task,
         _position: Position,
         widgets: &Self::RecordWidgets,
@@ -164,7 +164,7 @@ where Config: TasksListConfiguration + 'static,
         &widgets.root
     }
 
-    fn view(view_model: &mut Self::ViewModel, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
+    fn update(view_model: &mut Self::ViewModel, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
         match msg {
             TaskMsg::New => {
                 let description = view_model.new_task_description.text();

--- a/relm4-store-examples/examples/todo_2_generating_tasks/view/task_list.rs
+++ b/relm4-store-examples/examples/todo_2_generating_tasks/view/task_list.rs
@@ -129,7 +129,7 @@ impl<Config: TasksListConfiguration> StoreViewPrototype for TasksListViewModel<C
     }
 
     /// Function called when record is modified.
-    fn view_record(
+    fn view(
         record: Task,
         _position: Position,
         widgets: &Self::RecordWidgets,
@@ -151,7 +151,7 @@ impl<Config: TasksListConfiguration> StoreViewPrototype for TasksListViewModel<C
         &widgets.root
     }
 
-    fn view(view_model: &mut Self::ViewModel, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
+    fn update(view_model: &mut Self::ViewModel, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
         match msg {
             TaskMsg::New => {
                 let description = view_model.new_task_description.text();

--- a/relm4-store-examples/examples/todo_2_set_pagination/view/task_list.rs
+++ b/relm4-store-examples/examples/todo_2_set_pagination/view/task_list.rs
@@ -130,7 +130,7 @@ impl<Config: TasksListConfiguration> StoreViewPrototype for TasksListViewModel<C
     }
 
     /// Function called when record is modified.
-    fn view_record(
+    fn view(
         record: Task,
         _position: Position,
         widgets: &Self::RecordWidgets,
@@ -152,7 +152,7 @@ impl<Config: TasksListConfiguration> StoreViewPrototype for TasksListViewModel<C
         &widgets.root
     }
 
-    fn view(view_model: &mut Self::ViewModel, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
+    fn update(view_model: &mut Self::ViewModel, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
         match msg {
             TaskMsg::New => {
                 let description = view_model.new_task_description.text();

--- a/relm4-store-examples/examples/todo_2_single_scroll/view/task_list.rs
+++ b/relm4-store-examples/examples/todo_2_single_scroll/view/task_list.rs
@@ -144,7 +144,7 @@ where Config: TasksListConfiguration + 'static,
     }
 
     /// Function called when record is modified.
-    fn view_record(
+    fn view(
         record: Task,
         _position: Position,
         widgets: &Self::RecordWidgets,
@@ -166,7 +166,7 @@ where Config: TasksListConfiguration + 'static,
         &widgets.root
     }
 
-    fn view(view_model: &mut Self, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
+    fn update(view_model: &mut Self, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
         match msg {
             TaskMsg::New => {
                 let description = view_model.new_task_description.text();

--- a/relm4-store-examples/examples/todo_3/view/task_list.rs
+++ b/relm4-store-examples/examples/todo_3/view/task_list.rs
@@ -142,7 +142,7 @@ where Config: TasksListConfiguration + 'static,
     }
 
     /// Function called when record is modified.
-    fn view_record(
+    fn view(
         record: Task,
         _position: Position,
         widgets: &Self::RecordWidgets,
@@ -164,7 +164,7 @@ where Config: TasksListConfiguration + 'static,
         &widgets.root
     }
 
-    fn view(view_model: &mut Self::ViewModel, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
+    fn update(view_model: &mut Self::ViewModel, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
         match msg {
             TaskMsg::New => {
                 let description = view_model.new_task_description.text();

--- a/relm4-store-examples/examples/todo_3_sorted_store/view/task_list.rs
+++ b/relm4-store-examples/examples/todo_3_sorted_store/view/task_list.rs
@@ -142,7 +142,7 @@ where Config: TasksListConfiguration + 'static,
     }
 
     /// Function called when record is modified.
-    fn view_record(
+    fn view(
         record: Task,
         _position: Position,
         widgets: &Self::RecordWidgets,
@@ -164,7 +164,7 @@ where Config: TasksListConfiguration + 'static,
         &widgets.root
     }
 
-    fn view(view_model: &mut Self::ViewModel, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
+    fn update(view_model: &mut Self::ViewModel, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
         match msg {
             TaskMsg::New => {
                 let description = view_model.new_task_description.text();

--- a/relm4-store-examples/examples/todo_4/view/task_list.rs
+++ b/relm4-store-examples/examples/todo_4/view/task_list.rs
@@ -169,7 +169,7 @@ where Config: TasksListConfiguration + 'static,
     }
 
     /// Function called when record is modified.
-    fn view_record(
+    fn view(
         record: Task,
         _position: Position,
         widgets: &Self::RecordWidgets,
@@ -191,7 +191,7 @@ where Config: TasksListConfiguration + 'static,
         &widgets.root
     }
 
-    fn view(
+    fn update(
         view_model: &mut Self::ViewModel, 
         msg: <Self as ViewModel>::Msg, 
         _sender: Sender<<Self as ViewModel>::Msg>

--- a/relm4-store-examples/examples/window_behavior/view/task_list.rs
+++ b/relm4-store-examples/examples/window_behavior/view/task_list.rs
@@ -176,7 +176,7 @@ where
     }
 
     /// Function called when record is modified.
-    fn view_record(
+    fn view(
         record: Task,
         _position: Position,
         widgets: &Self::RecordWidgets,
@@ -198,7 +198,7 @@ where
         &widgets.root
     }
 
-    fn view(view_model: &mut Self, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
+    fn update(view_model: &mut Self, msg: <Self as ViewModel>::Msg, _sender: Sender<<Self as ViewModel>::Msg>) {
         match msg {
             TaskMsg::New => {
                 let description = view_model.new_task_description.text();

--- a/relm4-store-view-implementation/src/implementation/mod.rs
+++ b/relm4-store-view-implementation/src/implementation/mod.rs
@@ -562,7 +562,7 @@ where
                 
                 if let Some(record) = self.get(id) {
                     if let Some( widget ) = widgets.get_mut(id) {
-                        <Configuration as StoreViewPrototype>::view_record(record, position, &widget.widgets);
+                        <Configuration as StoreViewPrototype>::view(record, position, &widget.widgets);
                         if old_order_len > position.0 && old_order[position.0] != *id {
                             // things got reordered so we need to remove widget from old place and attach it to the new one
                             if let Some(widget) = widgets.remove(id) {

--- a/relm4-store-view-implementation/src/lib.rs
+++ b/relm4-store-view-implementation/src/lib.rs
@@ -251,7 +251,7 @@ where
     ) {
         let model = self.get(key).expect("Key doesn't point to the model in the store while updating! WTF?");
         let position = self.get_position(&model.get_id()).expect("Unsynchronized view with store! WTF?");
-        <Configuration as StoreViewPrototype>::view_record(model, position, widgets)
+        <Configuration as StoreViewPrototype>::view(model, position, widgets)
     }
 
     /// Get the outermost widget from the widgets.

--- a/relm4-store-view-implementation/tests/common/mod.rs
+++ b/relm4-store-view-implementation/tests/common/mod.rs
@@ -53,9 +53,9 @@ impl<Window: 'static + WindowBehavior + Debug> StoreViewPrototype for TestConfig
         }
     }
 
-    fn view_record(_model: <Self::Store as store::DataStore>::Record, _position: Position, _widgets: &Self::RecordWidgets) {}
+    fn view(_model: <Self::Store as store::DataStore>::Record, _position: Position, _widgets: &Self::RecordWidgets) {}
 
-    fn view(_view_model: &mut Self::ViewModel, _msg: (), _sender: Sender<()>) {}
+    fn update(_view_model: &mut Self::ViewModel, _msg: (), _sender: Sender<()>) {}
     
     fn init_view_model(_parent_view_model: &Self::ParentViewModel, _store_view: &Self::StoreView) -> Self::ViewModel {}
 

--- a/relm4-store/src/factory_prototype/mod.rs
+++ b/relm4-store/src/factory_prototype/mod.rs
@@ -65,6 +65,8 @@ pub trait StoreViewPrototype
 
     /// Creates instance of the [Self::RecordWidgets] responsible for displaying `record`
     /// at the `position`
+    /// 
+    /// This method is equivalent of [FactoryPrototype::init_view][relm4::factory::FactoryPrototype::init_view]
     fn init_view(
         record: &<Self::Store as DataStore>::Record,
         position: Position,
@@ -73,14 +75,18 @@ pub trait StoreViewPrototype
 
     /// Function called when record in store view is modified and you need to 
     /// synchronize the state of the view with data in the model
-    fn view_record(
+    /// 
+    /// This method is equivalent of [FactoryPrototype::view][relm4::factory::FactoryPrototype::view]
+    fn view(
         model: <Self::Store as DataStore>::Record,
         position: Position,
         widgets: &Self::RecordWidgets,
     );
 
     /// Function called when component received a message
-    fn view(
+    /// 
+    /// This method is equivalent of [ComponentUpdate::update][relm4::ComponentUpdate::update]
+    fn update(
         view_model: &mut Self::ViewModel,
         msg: <Self::ViewModel as ViewModel>::Msg,
         sender: Sender<<Self::ViewModel as ViewModel>::Msg>,
@@ -89,17 +95,23 @@ pub trait StoreViewPrototype
     /// Creates new instance of [StoreViewPrototype]
     /// 
     /// If you wish to use store view in widgets you must save it in your model
+    /// 
+    /// This method is equivalent of [ComponentUpdate::init_model][relm4::ComponentUpdate::init_model]
     fn init_view_model(parent_view_model: &Self::ParentViewModel, store_view: &Self::StoreView) -> Self::ViewModel;
 
     /// Returns position of record inside the widget
     /// 
     /// Useful for [gtk::Grid]
+    /// 
+    /// This method is equivalent of [FactoryPrototype::position][relm4::factory::FactoryPrototype::position]
     fn position(
         model: <Self::Store as DataStore>::Record, 
         position: Position,
     ) -> <Self::View as FactoryView<Self::Root>>::Position;
 
     /// Get the outermost widget from the widgets.
+    /// 
+    /// This method is equivalent of [FactoryPrototype::root_widget][relm4::factory::FactoryPrototype::root_widget]
     fn root_widget(widgets: &Self::RecordWidgets) -> &Self::Root;
 }
 

--- a/relm4-store/src/store_view_component/mod.rs
+++ b/relm4-store/src/store_view_component/mod.rs
@@ -164,7 +164,7 @@ where
             receiver.attach(Some(&context), move |msg| {
                 if let Ok(mut view_model) = handler_view_model.try_borrow_mut() {
                     if let Ok(mut container) = handler_container.try_borrow_mut() {
-                        Configuration::view(&mut view_model, msg, handler_sender.clone());
+                        Configuration::update(&mut view_model, msg, handler_sender.clone());
                         container.view(&view_model, handler_sender.clone());
                         send!(handler_redraw_sender, RedrawMessages::Redraw);
                     }


### PR DESCRIPTION
- more closly follow FactoryPrototype for methods which do the same
- bring back `update` so it follows `ComponentUpdate`

Documentation updates