### PR TITLE
WindowBehavior fixes

### DIFF
--- a/book/releases/0.1-beta.3.md
+++ b/book/releases/0.1-beta.3.md
@@ -14,6 +14,12 @@ Early beta
 
 Various adjustments were made to WindowBehavior implementations to make them behave more like advertised. In most cases no action should be needed.
 
+List of updated behaviors
+
+- ValueTrackingWindow
+- KeepOnTop
+- KeepOnBottom
+
 ### Updates to `relm4-store::window::WindowTransition`
 
 Two new states were identified in which window can change. `TransitionLeft(usize)` and `TransitionRight(usize)`. If window behavior will return this states it means that only position of the elements in the store changed. No content of the record was changed.

--- a/book/releases/0.1-beta.3.md
+++ b/book/releases/0.1-beta.3.md
@@ -6,7 +6,13 @@ Early beta
 
 ## Changes
 
+- Various fixes in implementations of WindowBehavior
+
 ## Migration from 0.1-beta.2
+
+### WindowBehavior
+
+Various adjustments were made to WindowBehavior implementations to make them behave more like advertised. In most cases no action should be needed.
 
 ### Updates to `relm4-store::window::WindowTransition`
 

--- a/relm4-store/src/window/keep_on_top.rs
+++ b/relm4-store/src/window/keep_on_top.rs
@@ -35,11 +35,17 @@ impl WindowBehavior for KeepOnTop {
     /// remove right is returned since all possible data can
     /// only come from right side
     fn remove(state: &StoreState<'_>, p: &Point) -> WindowTransition {
-        if p >= state.page.end() {
+        if p >= state.page.end() { // Case 2
             WindowTransition::Identity
         }
-        else {
-            WindowTransition::RemoveRight{
+        else if p < state.page.start() { // Case 1
+            WindowTransition::RemoveRight {
+                pos: *state.page.start(),
+                by: 1,
+            }
+        }
+        else { // Case 3
+            WindowTransition::RemoveRight {
                 pos: p.value(),
                 by: 1,
             }


### PR DESCRIPTION
KeepOnTop in add and remove now behaves as PositionTrackingWindow

Notes to the release page of the book