### PR TITLE
Store view slide

### DIFF
--- a/book/releases/0.1-beta.3.md
+++ b/book/releases/0.1-beta.3.md
@@ -7,6 +7,8 @@ Early beta
 ## Changes
 
 - Various fixes in implementations of WindowBehavior
+- `relm4_store_collections::data_container::DataContainer` updates and fixes
+- `relm4_store_collections::data_container::WindowChangeset` was moved
 
 ## Migration from 0.1-beta.2
 
@@ -36,3 +38,23 @@ Two new states were identified in which window can change. `TransitionLeft(usize
 | `TransitionRight(by)` | Position of shown records in store was changed by `by`. We are still showing the same records.  | All records will have update method called, since position is part of the `StoreViewPrototype::view` signature |
 | `SlideLeft(by)`       | View windows was moved for a `by` records to the left. We need to hide `by` records from right to show `by` records from left | `by` records will be added in the ui from left, and `by` records will be removed from right. Records which are outside of the slide range will not be updated |
 | `SlideRight(by)`      | View windows was moved for a `by` records to the right. We need to hide `by` records from left to show `by` records from right | `by` records will be added in the ui from right, and `by` records will be removed from left. Records which are outside of the slide range will not be updated |
+
+### DataContainer
+
+#### Moved to the `data_container`
+
+Beta.2 allowed access to the `DataContainer` via `relm4_store_collections::DataContainer`. Now it's available as `relm4_store_collections::data_container::DataContainer`.
+
+#### remove_left behavior change
+
+Before the update there was a bug in the `DataContainer::left_remove` where records passed in `left_records` were inserted in wrong order into the container.
+
+> If you had a container `[a, b, c, d, e]` and asked to remove left at position 4 two elements and insert left records [1, 2] then old behavior resulted in the container
+> looking `[2, 1, a, b, d, e]` while it should `[1, 2, a, b, d, e]`
+
+Now it behaves as expected.
+
+### WindowChangeset
+
+Beta.2 allowed access to the `WindowChangeset` via `relm4_store_collections::WindowChangeset`. Now it's available as `relm4_store_collections::data_container::WindowChangeset`.
+`WindowChangeset` is part of the `DataContainer` so the move there caused this changes

--- a/relm4-store-backend-dummy/src/test_cases/mod.rs
+++ b/relm4-store-backend-dummy/src/test_cases/mod.rs
@@ -2,9 +2,12 @@
 mod add;
 mod add_multistep;
 mod remove;
+mod test_case_builder;
 
 #[cfg(test)]
 mod tests;
+
+pub use test_case_builder::TestCaseBuilder;
 
 use record::DefaultIdAllocator;
 use record::TemporaryIdAllocator;
@@ -16,9 +19,6 @@ use uuid::Uuid;
 use record::Id;
 use record::Record;
 use super::DummyBackendConfiguration;
-
-
-
 
 /// Sample record for test cases
 #[derive(Debug, Clone)]

--- a/relm4-store-backend-dummy/src/test_cases/test_case_builder.rs
+++ b/relm4-store-backend-dummy/src/test_cases/test_case_builder.rs
@@ -1,0 +1,82 @@
+use store::Position;
+use store::StoreViewMsg;
+
+use crate::DummyBackendConfiguration;
+use crate::configuration::Step;
+
+use super::TestCase;
+use super::TestRecord;
+
+
+/// TestCaseBuilder
+#[derive(Debug)]
+pub struct TestCaseBuilder {
+    test_case: TestCase
+}
+
+impl TestCaseBuilder {
+    /// Creates "size amount of initial data"
+    pub fn initial_size(mut self, size: usize) -> Self {
+        let mut initial_data = Vec::with_capacity(size);
+
+        for idx in 0..size {
+            initial_data.push(TestRecord::constant(&format!("Initial test record {}", idx)))
+        }
+
+        self.test_case.data = initial_data.clone();
+        self.test_case.configuration.initial_data = initial_data;
+
+        self
+    }
+
+    /// Adds a step
+    pub fn add_step(mut self) -> Self {
+        let last_step_data = {
+            let steps = &self.test_case.configuration.steps;
+            if steps.len() > 0 {
+                steps[steps.len() - 1].data.clone()
+            }
+            else {
+                self.test_case.configuration.initial_data.clone()
+            }
+        };
+
+
+        self.test_case.configuration.steps.push(Step{
+            data: last_step_data,
+            events: vec![],
+        });
+
+        self
+    }
+
+    /// Slides a given step to the position
+    /// 
+    /// You must add a step before running this method
+    pub fn slide(mut self, position: usize) -> Self {
+        let step = self.test_case.configuration.steps.len() - 1;
+
+        self.test_case.configuration.steps[step].events.push(StoreViewMsg::SlideTo(Position(position)));
+
+        self
+    }
+
+    /// Returns constructed test case
+    pub fn build(self) -> TestCase {
+        self.test_case
+    }
+}
+
+impl Default for TestCaseBuilder{
+    fn default() -> Self {
+        TestCaseBuilder{
+            test_case: TestCase{
+                configuration: DummyBackendConfiguration{
+                    steps: vec![],
+                    initial_data: vec![],
+                },
+                data: vec![],
+            }
+        }
+    }
+}

--- a/relm4-store-collections/src/data_container/tests/insert_left.rs
+++ b/relm4-store-collections/src/data_container/tests/insert_left.rs
@@ -18,7 +18,7 @@ fn insert_left_first_record_at_0() {
 
     dc.insert_left(&mut changeset, position, records);
 
-    dc.invariants();
+    dc.invariants("insert_left_first_record_at_0");
     assert_eq!(dc.len(), 1);
     assert_eq!(dc.data[&record.get_id()], record);
     assert_eq!(dc.order[0], record.get_id());
@@ -35,7 +35,7 @@ fn insert_left_second_two_records() {
 
     dc.insert_left(&mut changeset, position, records);
 
-    dc.invariants();
+    dc.invariants("insert_left_second_two_records");
     assert_eq!(dc.len(), 2);
     assert_eq!(dc.data[&record1.get_id()], record1);
     assert_eq!(dc.data[&record2.get_id()], record2);
@@ -55,7 +55,7 @@ fn insert_left_three_records() {
 
     dc.insert_left(&mut changeset, position, records);
 
-    dc.invariants();
+    dc.invariants("insert_left_three_records");
     assert_eq!(dc.len(), 3);
     assert_eq!(dc.data[&record1.get_id()], record1);
     assert_eq!(dc.data[&record2.get_id()], record2);
@@ -71,7 +71,7 @@ mod max_size_3 {
     use backend_dummy::test_cases::TestRecord;
     use record::Record;
     
-    use crate::WindowChangeset;
+    use super::WindowChangeset;
 
     use super::TestData;
 

--- a/relm4-store-collections/src/data_container/tests/insert_right.rs
+++ b/relm4-store-collections/src/data_container/tests/insert_right.rs
@@ -3,7 +3,7 @@
 use backend_dummy::test_cases::TestRecord;
 use record::Record;
 
-use crate::WindowChangeset;
+use crate::data_container::WindowChangeset;
 use crate::data_container::DataContainer;
 use super::test_data::TestData;
 
@@ -17,7 +17,7 @@ fn insert_right_first_record() {
 
     dc.insert_right(&mut changeset, position, records);
 
-    dc.invariants();
+    dc.invariants("insert_right_first_record");
     assert_eq!(dc.data[&record.get_id()], record);
     assert_eq!(dc.order[0], record.get_id());
 }
@@ -33,7 +33,7 @@ fn insert_right_second_two_records() {
 
     dc.insert_right(&mut changeset, position, records);
 
-    dc.invariants();
+    dc.invariants("insert_right_second_two_records");
     assert_eq!(dc.len(), 2);
     assert_eq!(dc.data[&record1.get_id()], record1);
     assert_eq!(dc.data[&record2.get_id()], record2);
@@ -53,7 +53,7 @@ fn insert_right_three_records() {
 
     dc.insert_right(&mut changeset, position, records);
 
-    dc.invariants();
+    dc.invariants("insert_right_three_records");
     assert_eq!(dc.len(), 3);
     assert_eq!(dc.data[&record1.get_id()], record1);
     assert_eq!(dc.data[&record2.get_id()], record2);
@@ -69,7 +69,7 @@ mod max_size_3 {
     use backend_dummy::test_cases::TestRecord;
     use record::Record;
     
-    use crate::WindowChangeset;
+    use super::WindowChangeset;
 
     use super::TestData;
 

--- a/relm4-store-collections/src/data_container/tests/remove_left.rs
+++ b/relm4-store-collections/src/data_container/tests/remove_left.rs
@@ -1,7 +1,7 @@
 use backend_dummy::test_cases::TestRecord;
 use record::Record;
 
-use crate::WindowChangeset;
+use crate::data_container::WindowChangeset;
 use crate::data_container::DataContainer;
 
 use super::test_data::TestData;
@@ -797,14 +797,6 @@ mod records_3 {
         assert!(changeset.add_contains(&right_records[1].get_id()));
     }
 
-    /// ----------------------------------
-    /// ----------------------------------
-    /// ----------------------------------
-    /// ----------------------------------
-    /// ----------------------------------
-    /// ----------------------------------
-    /// ----------------------------------
-
     #[test]
     fn remove_last_element_insert_2_2() {
         let TestData{ records, mut container } = TestData::new(RECORDS_CNT, MAX_SIZE);
@@ -863,5 +855,51 @@ mod records_3 {
         container.remove_left(&mut changeset, MAX_SIZE, MAX_SIZE, left_records, right_records);
 
         assert_eq!(container.len(), 0);
+    }
+}
+
+mod full {
+    use super::Record;
+    use super::TestData;
+    use super::TestRecord;
+    use super::WindowChangeset;
+
+    const RECORDS_CNT: usize = 10;
+    const MAX_SIZE: usize = 10;
+
+    /// Position: 10
+    /// By: 5
+    /// Starting len: 10
+    /// Left records len: 5
+    /// Right records len: 0
+    /// Data len: 10
+    /// Order len: 10
+    #[test]
+    fn remove_5_at_10_starting_len_5_left_records_5_right_records_0() {
+        let TestData{ records, mut container } = TestData::new(RECORDS_CNT, MAX_SIZE);
+        let mut changeset: WindowChangeset<TestRecord> = WindowChangeset::default();
+
+        let left_records = vec![
+            TestRecord::since("New record 1", 1),
+            TestRecord::since("New record 2", 2),
+            TestRecord::since("New record 3", 3),
+            TestRecord::since("New record 4", 4),
+            TestRecord::since("New record 5", 5),
+        ];
+        let right_records = vec![];
+
+        container.remove_left(&mut changeset, 10, 5, left_records.clone(), right_records);
+
+        assert_eq!(container.len(), 10);
+
+        for idx in 0..5 {
+            assert_eq!(container.data[&left_records[idx].get_id()], left_records[idx]);
+            assert_eq!(container.data[&records[idx].get_id()], records[idx]);
+            assert_eq!(container.order[idx], left_records[idx].get_id());
+            assert_eq!(container.order[idx+5], records[idx].get_id());
+            assert!(changeset.remove_contains(&records[idx+5].get_id()));
+            assert!(changeset.add_contains(&left_records[idx].get_id()));
+            assert!(!changeset.update_contains(&records[idx].get_id()));
+        }
     }
 }

--- a/relm4-store-collections/src/data_container/tests/remove_right.rs
+++ b/relm4-store-collections/src/data_container/tests/remove_right.rs
@@ -1,7 +1,7 @@
 use backend_dummy::test_cases::TestRecord;
 use record::Record;
 
-use crate::WindowChangeset;
+use crate::data_container::WindowChangeset;
 use crate::data_container::DataContainer;
 
 use super::test_data::TestData;
@@ -15,7 +15,7 @@ fn remove_right_from_empty_container() {
     let records = vec![];
 
     dc.remove_right(&mut changeset, 0, 3, records);
-    dc.invariants();
+    dc.invariants("remove_right_from_empty_container");
 
     assert_eq!(dc.len(), 0);
 }
@@ -28,7 +28,7 @@ fn remove_right_from_empty_container_outside_of_the_range() {
     let records = vec![];
 
     dc.remove_right(&mut changeset, 5, 3, records);
-    dc.invariants();
+    dc.invariants("remove_right_from_empty_container");
 
     assert_eq!(dc.len(), 0);
 }

--- a/relm4-store-collections/src/data_container/tests/test_data.rs
+++ b/relm4-store-collections/src/data_container/tests/test_data.rs
@@ -1,7 +1,7 @@
 use backend_dummy::test_cases::TestRecord;
 use record::Record;
 
-use crate::WindowChangeset;
+use crate::data_container::WindowChangeset;
 use crate::data_container::DataContainer;
 
 

--- a/relm4-store-collections/src/lib.rs
+++ b/relm4-store-collections/src/lib.rs
@@ -14,10 +14,7 @@
     unreachable_pub
 )]
 
-mod data_container;
-
-pub use data_container::DataContainer;
-pub use data_container::WindowChangeset;
+pub mod data_container;
 
 // mod tree;
 

--- a/relm4-store-view-implementation/src/implementation/mod.rs
+++ b/relm4-store-view-implementation/src/implementation/mod.rs
@@ -294,7 +294,6 @@ where
             else {
                 Range::new(range_start - range_of_changes_len, range_start)
             };
-            println!("Left range: {:?}", left_range);
             self.store.get_range(&left_range)
         }
         else {
@@ -335,19 +334,13 @@ where
             changeset.update(*id);
         }
 
-        let range_start = {
+        let range = {
             let range = self.range.borrow();
-            *range.start()
+            *range
         };
 
-        let new_start = if range_start < by {
-            0
-        }
-        else {
-            range_start - by
-        };
+        let new_range = range.to_left(by);
 
-        let new_range = Range::new(new_start, new_start + self.size);
         self.range.replace(new_range);
     }
 
@@ -367,6 +360,56 @@ where
 
         let new_range = Range::new(new_start, new_start + self.size);
         self.range.replace(new_range);
+    }
+
+    fn slide_left(&self, changeset: &mut WindowChangeset<<Configuration::Store as DataStore>::Record>, by: usize) {
+        // This implementation is suboptimal
+        //
+        // We don't check for data overlap and just do a reload it works but can be made much faster
+        let range = {
+            *self.range.borrow()
+        };
+
+        let new_range = range.to_left(by);
+        
+        self.range.replace(new_range);
+        if self.size <= by {
+            //we've scrolled more then a size of a page.
+            log::trace!("Slide left: reload");
+            self.reload(changeset);
+        }
+        else {
+            log::trace!("Slide left: remove_left");
+            let real_move_size = range.start() - new_range.start();
+            let mut view = self.view.borrow_mut();
+            let left_range = Range::new(*new_range.start(), new_range.start() + real_move_size);
+            let left_data = self.store.get_range(&left_range);
+
+            view.remove_left(changeset, *new_range.end(), real_move_size, left_data, vec![]);
+        }
+    }
+
+    fn slide_right(&self, changeset: &mut WindowChangeset<<Configuration::Store as DataStore>::Record>, by: usize) {
+        let range = {
+            *self.range.borrow()
+        };
+
+        let new_range = range.to_right(by);
+
+        self.range.replace(new_range);
+        if self.size <= by {
+            log::trace!("Slide right: reload");
+            self.reload(changeset);
+        }
+        else {
+            log::trace!("Slide right: remove_right");
+            
+            let mut view = self.view.borrow_mut();
+            let data_range = Range::new(new_range.end() - by, *new_range.end());
+            let data = self.store.get_range(&data_range);
+
+            view.remove_right(changeset, 0, by, data);
+        }
     }
 
     fn compile_changes(&self) -> WindowChangeset<<Configuration::Store as DataStore>::Record> {
@@ -429,76 +472,12 @@ where
                 }
                 WindowTransition::SlideLeft(by) => {
                     log::trace!("SlideLeft");
+                    self.slide_left(&mut changeset, by);
 
-                    // This implementation is suboptimal
-                    //
-                    // We don't check for data overlap and just do a reload it works but can be made much faster
-                    //TODO: Check for data overlap and update what is necessary
-                    let range = {
-                        *self.range.borrow()
-                    };
-
-                    let start = *range.start();
-
-                    let new_range = if start < by {
-                        range.slide(0)
-                    }
-                    else {
-                        range.slide(start - by)
-                    };
-
-                    self.range.replace(new_range);
-
-                    self.reload(&mut changeset);
                 }
                 WindowTransition::SlideRight(by) => {
-                    //exceeds is true if we try to slide outside of available data
-                    let exceeds = {
-                        let range = self.range.borrow();
-                        self.len() >= range.end() + by
-                    };
-
-                    if by > self.size || exceeds {
-                        // Two cases solved here
-                        // 1. Sliding more then page size, so we must reload whole range
-                        // 2. Trying to go outside of data range of the store
-                        //   2.1 There is less data in the store then one page so keep being on the first page
-                        //   2.2 In all other cases stay on the last page
-                        //
-                        // TODO: Check in case 2 if we can reuse the data which already are in the store
-                        //   currently we don't check for data overlap, just force a full reload which might
-                        //   be more expensive then needed
-                        let new_range = {
-                            let range = self.range.borrow();
-                            let new_end = range.end() + by;
-                            if new_end > self.len() {
-                                // Case 2
-                                if self.size > self.len() {
-                                    // Case 2.2
-                                    range.slide(self.len()-self.size)
-                                }
-                                else {
-                                    // Case 2.1
-                                    range.slide(0)
-                                }
-                            }
-                            else {
-                                // Case 1
-                                range.slide(range.start()+by)
-                            }
-                        };
-
-                        self.range.replace(new_range);
-                        self.reload(&mut changeset);
-                    }
-                    else {
-                        let new_range = {
-                            let range = self.range.borrow();
-                            range.slide(range.start() + by)
-                        };
-                        self.range.replace(new_range);
-                        self.reload(&mut changeset);
-                    }
+                    log::trace!("SlideRight");
+                    self.slide_right(&mut changeset, by);
                 }
                 
             }

--- a/relm4-store-view-implementation/src/lib.rs
+++ b/relm4-store-view-implementation/src/lib.rs
@@ -15,6 +15,7 @@ use reexport::log;
 use reexport::relm4::factory::Factory;
 use reexport::relm4::factory::FactoryPrototype;
 use reexport::relm4::factory::FactoryView;
+use store::Position;
 use store::StoreView;
 use store::StoreViewMsg;
 use store::math::Range;
@@ -161,8 +162,8 @@ where
     }
 
     fn set_window(&self, range: store::math::Range) {
-        self.implementation.borrow().set_window(range);
-        self.send(StoreViewMsg::Reload);
+        // self.implementation.borrow().set_window(range);
+        self.send(StoreViewMsg::SlideTo(Position(*range.start())));
     }
 
     fn get_view_data(&self) -> Vec<store::RecordWithLocation<Self::Record>> {

--- a/relm4-store-view-implementation/tests/store_view_implementation/mod.rs
+++ b/relm4-store-view-implementation/tests/store_view_implementation/mod.rs
@@ -4,3 +4,5 @@ mod keep_on_bottom;
 mod keep_on_top;
 mod position_tracking_window;
 mod value_tracking_window;
+
+mod slide;

--- a/relm4-store-view-implementation/tests/store_view_implementation/slide/mod.rs
+++ b/relm4-store-view-implementation/tests/store_view_implementation/slide/mod.rs
@@ -1,0 +1,89 @@
+use store::window::PositionTrackingWindow;
+use crate::common::StoreViewTest;
+
+// sliding is independent form window behavior so which behavior we use doesn't matter
+type ST = StoreViewTest<PositionTrackingWindow>;
+
+mod last_page {
+    use backend_dummy::test_cases::TestCaseBuilder;
+    use serial_test::serial;
+    use store::Position;
+    use store::StoreSize;
+    use store::StoreView;
+
+    use super::ST;
+
+    #[test]
+    #[serial(gtk)]
+    fn slide_left_by_1_of_10() {
+        let slide1 = 15;
+        let slide2 = 14;
+        let page_size1 = 10;
+
+        let tc = TestCaseBuilder::default()
+            .initial_size(30)
+            .add_step()
+            .slide(slide1)
+            .add_step()
+            .slide(slide2)
+            .build();
+
+
+        ST::from(tc)
+            .window_size(StoreSize::Items(page_size1))
+            .step(&|test_data, store_view, _|{
+                let data = store_view.get_view_data();
+
+                for idx in 0..10 {
+                    assert_eq!(data[idx].record, test_data[idx+15]);
+                    assert_eq!(data[idx].position, Position(idx+15));
+                }
+            })
+            .step(&|test_data, store_view, _|{
+                let data = store_view.get_view_data();
+
+                for idx in 0..10 {
+                    assert_eq!(data[idx].record, test_data[idx+14]);
+                    assert_eq!(data[idx].position, Position(idx+14));
+                }
+            })
+            .run();
+    }
+
+    #[test]
+    #[serial(gtk)]
+    fn slide_left_by_5_of_10() {
+        let slide1 = 15;
+        let slide2 = 10;
+        let page_size1 = 10;
+
+        let tc = TestCaseBuilder::default()
+            .initial_size(30)
+            .add_step()
+            .slide(slide1)
+            .add_step()
+            .slide(slide2)
+            .build();
+
+
+        ST::from(tc)
+            .window_size(StoreSize::Items(page_size1))
+            .step(&|test_data, store_view, _|{
+                let data = store_view.get_view_data();
+
+                for idx in 0..10 {
+                    assert_eq!(data[idx].record, test_data[idx+15]);
+                    assert_eq!(data[idx].position, Position(idx+15));
+                }
+            })
+            .step(&|test_data, store_view, _|{
+                let data = store_view.get_view_data();
+
+                for idx in 0..10 {
+                    assert_eq!(data[idx].record, test_data[idx+10]);
+                    assert_eq!(data[idx].position, Position(idx+10));
+                }
+            })
+            .run();
+    }
+}

--- a/relm4-store-view-implementation/tests/store_view_implementation/value_tracking_window/remove.rs
+++ b/relm4-store-view-implementation/tests/store_view_implementation/value_tracking_window/remove.rs
@@ -126,7 +126,6 @@ mod first_page {
                 let range = store_view.get_window();
                 assert_eq!(range, Range::new(0, 10));
                 let data = store_view.get_view_data();
-                // println!("Data in the view: {:#?}", data);
                 assert_eq!(data[9].position, Position(9));
                 assert_eq!(data[9].record, test_data[10]);
             })

--- a/relm4-store/src/store_view_msg.rs
+++ b/relm4-store/src/store_view_msg.rs
@@ -30,4 +30,6 @@ pub enum StoreViewMsg<T: Record> {
     Update(Id<T>),
     /// Store should be reloaded fully, dump all data, indexes, etc... and reload the data
     Reload,
+    /// Move the window such that first shown record is at given position
+    SlideTo(Position),
 }


### PR DESCRIPTION
Now sliding only touches widgets which are

- added to the view, since we are showing a new part of the store after slide
- removed since, they no longer are visible in the visible region of the store

closing #34
